### PR TITLE
fix: optional 3rd match group in parse_stacktrace

### DIFF
--- a/flytrap/utils/stack_trace.py
+++ b/flytrap/utils/stack_trace.py
@@ -15,7 +15,7 @@ def parse_stack_trace(error: Exception) -> list[dict] | None:
     for line in stack_lines:
         match = re.match(pattern, line)
         if match:
-            file, line_number = match.groups()
+            file, line_number, _ = match.groups()
             stack_frames.append({
                 'file': file,
                 'line': int(line_number),


### PR DESCRIPTION
Fixed a typo to allow for optional 3rd match group in parse_stacktrace to not break the app if they happen.